### PR TITLE
Add a lock mechanism to the migration jobs

### DIFF
--- a/deployMigrationJobPod.sh
+++ b/deployMigrationJobPod.sh
@@ -16,10 +16,10 @@ oc process -f migration-cm.yml \
     -p CLEANUP_SINGLE_TENANT="${CLEANUP_SINGLE_TENANT}" \
     -p CHE_MULTITENANT_SERVER="${CHE_MULTITENANT_SERVER}" \
     -p REQUEST_ID="${REQUEST_ID}" \
-    | oc apply --force -f -
+    | oc apply --overwrite=true --force -f -
 
 
 oc process -f namespace-migration.yml \
     -p IMAGE="${MIGRATION_IMAGE}" \
     -p REQUEST_ID="${REQUEST_ID}" \
-    | oc apply --force -f -
+    | oc apply --overwrite=true --force -f -

--- a/namespace-migration.yml
+++ b/namespace-migration.yml
@@ -67,6 +67,8 @@ objects:
                 key: request-id
                 name: migration
                 optional: true
+          - name: JOB_REQUEST_ID
+            value: ${REQUEST_ID}
           image: ${IMAGE}
           imagePullPolicy: "Always"
         restartPolicy: Never

--- a/source/io/fabric8/tenant/che/migration/namespace/cleanup.ceylon
+++ b/source/io/fabric8/tenant/che/migration/namespace/cleanup.ceylon
@@ -145,9 +145,11 @@ Boolean cleanSingleTenantCheServer() {
     return true;
 }
 
-void cleanMigrationResources() {
+void cleanMigrationResources(String jobRequestId) {
     try(oc = DefaultOpenShiftClient()) {
-        if (exists configMap = oc.configMaps().inNamespace(osioCheNamespace(oc)).withName("migration").get()) {
+        if (exists configMap = oc.configMaps().inNamespace(osioCheNamespace(oc)).withName("migration").get(),
+            exists reqId = configMap.data.get(JavaString("request-id"))?.string,
+            reqId == jobRequestId) {
             oc.resource(configMap).delete();
         }
     } catch(Exception e) {

--- a/source/io/fabric8/tenant/che/migration/namespace/common.ceylon
+++ b/source/io/fabric8/tenant/che/migration/namespace/common.ceylon
@@ -14,6 +14,7 @@ object env {
     shared String? cheNamespace = get("CHE_NAMESPACE");
     shared String? debugLogs = get("DEBUG");
     shared String? cleanupSingleTenant = get("CLEANUP_SINGLE_TENANT");
+    shared String? jobRequestId = get("JOB_REQUEST_ID");
 }
 String cheSingleTenantCheServerName="che";
 String cheSingleTenantCheServerRoute="che";

--- a/source/io/fabric8/tenant/che/migration/namespace/endpoints.ceylon
+++ b/source/io/fabric8/tenant/che/migration/namespace/endpoints.ceylon
@@ -13,11 +13,7 @@ shared class NamespaceEndpoint() {
     get
     produces {MediaType.applicationJson}
     shared Integer migrate(queryParam("debug") String? debug = null) {
-        try {
-            return doMigration(debug);
-        } finally {
-            cleanMigrationResources();
-        }
+        return doMigration(debug);
     }
 
     get


### PR DESCRIPTION
Add a lock mechanism to the migration jobs so that:
- jobs that correspond to a different request id as the current
config map request id are skipped,
- a job would wait then end of any previous job before starting
the migration if still necessary.

Signed-off-by: David Festal <dfestal@redhat.com>