### PR TITLE
Fix a possible NPE, and avoid the SLF4J non-JSON STDOUT messages.

### DIFF
--- a/fabric8-tenant-che-migration.iml
+++ b/fabric8-tenant-che-migration.iml
@@ -62,6 +62,7 @@
     <orderEntry type="library" scope="PROVIDED" name="Ceylon: org.jboss.xnio:xnio-api/3.3.6.Final" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Ceylon: org.slf4j:jul-to-slf4j/1.7.13" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Ceylon: org.slf4j:slf4j-api/1.7.13" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Ceylon: org.slf4j:slf4j-nop/1.7.13" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Ceylon: org.yaml:snakeyaml/1.15" level="project" />
   </component>
 </module>

--- a/source/io/fabric8/tenant/che/migration/namespace/cleanup.ceylon
+++ b/source/io/fabric8/tenant/che/migration/namespace/cleanup.ceylon
@@ -28,8 +28,14 @@ import java.util {
     JavaMap=Map
 }
 
-Map<String, String> toCeylon(JavaMap<JavaString, JavaString> javaMap) =>
-        map { for (e in javaMap.entrySet()) e.key.string -> e.\ivalue.string };
+Map<String, String> toCeylon(JavaMap<JavaString, JavaString>? javaMap) =>
+        if(exists javaMap)
+        then map {
+            for (e in javaMap.entrySet())
+                if(exists key = e.key, exists item = e.\ivalue)
+                    key.string -> item.string
+        }
+        else map {};
 
 Boolean isCheServerPod(Pod pod)
         => toCeylon(pod.metadata.labels).containsEvery {

--- a/source/io/fabric8/tenant/che/migration/namespace/module.ceylon
+++ b/source/io/fabric8/tenant/che/migration/namespace/module.ceylon
@@ -4,4 +4,5 @@ module io.fabric8.tenant.che.migration.namespace "1.0.0" {
     shared import io.fabric8.tenant.che.migration.workspaces "1.0.0";
     import maven:io.fabric8:"openshift-client" "2.6.3";
     import ceylon.interop.java "1.3.3";
+    import maven:"org.slf4j:slf4j-nop" "1.7.13";
 }

--- a/source/io/fabric8/tenant/che/migration/workspaces/module.ceylon
+++ b/source/io/fabric8/tenant/che/migration/workspaces/module.ceylon
@@ -8,4 +8,5 @@ module io.fabric8.tenant.che.migration.workspaces "1.0.0" {
     import fr.minibilles.cli "0.2.1";
     shared import ceylon.logging "1.3.3";
     shared import java.base "8";
+    import maven:"org.slf4j:slf4j-nop" "1.7.13";
 }


### PR DESCRIPTION
- The fixed NPE is the one that occured [here](https://logs.dsaas.openshift.com/app/kibana#/doc/project.dsaas-production.129c1244-1b37-11e7-8db9-124160897002.*/project.dsaas-production.129c1244-1b37-11e7-8db9-124160897002.2017.12.19/com.redhat.viaq.common?id=AWBut5V8YV0AHSApGfsj&_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:now-15m,mode:quick,to:now)))
- And the removal of the undesired SLF4J warning on STDOUT should allow Kibana to correctly parse the further log entries as JSON (which seems to *not* be the case for now)

Signed-off-by: David Festal <dfestal@redhat.com>