### PR TITLE
Catch `SocketTimeoutException`s inside the Che route waiting loop.

### DIFF
--- a/source/io/fabric8/tenant/che/migration/workspaces/MigrationTool.ceylon
+++ b/source/io/fabric8/tenant/che/migration/workspaces/MigrationTool.ceylon
@@ -30,6 +30,9 @@ import java.util.concurrent {
 import java.lang {
     Thread
 }
+import java.net {
+    SocketTimeoutException
+}
 
 String exitCodes => "Possible exit codes:\n\n" +
     "\n".join(Status.statuses.sort(byKey(increasing<Integer>))
@@ -121,6 +124,10 @@ class MigrationTool(
                     else {
                         return Status.unexpectedErrorInSourceCheServer(response);
                     }
+                } catch(SocketTimeoutException e) {
+                    log.info("SocketTimeout exception when trying to access to the Single-tenant Che server. Retrying ...");
+                    // Wait 1 second and retry
+                    Thread.sleep(1000);
                 }
             } else {
                 log.error("Single-tenant Che server not accessible even after ``timeoutMinutes`` minutes at '`` sourceEndpoint ``'");


### PR DESCRIPTION
This should help being more robust in the use-cases leading to errors like [this one](https://logs.dsaas.openshift.com/app/kibana#/doc/project.dsaas-production.129c1244-1b37-11e7-8db9-124160897002.*/project.dsaas-production.129c1244-1b37-11e7-8db9-124160897002.2017.12.20/com.redhat.viaq.common/?id=AWB1GgR9p6mYn5lhHBpC)

Signed-off-by: David Festal <dfestal@redhat.com>