### PR TITLE
Prepare the migration tool to interact with the `che-starter`

### DIFF
--- a/openshift/che-tenant-maintainer.app.yml
+++ b/openshift/che-tenant-maintainer.app.yml
@@ -38,6 +38,8 @@ objects:
             value: http://che-host:8080/wsmaster/api
           - name: CHE_DESTINATION_SERVER
             value: http://rhche-host:8080/api
+          - name: OS_MASTER_URL
+            value: http://f8osoproxy:8080
           image: ${IMAGE}:${IMAGE_TAG}
           imagePullPolicy: Always
           livenessProbe:

--- a/source/io/fabric8/tenant/che/migration/namespace/MigrationEndpoint.ceylon
+++ b/source/io/fabric8/tenant/che/migration/namespace/MigrationEndpoint.ceylon
@@ -4,20 +4,69 @@ import fr.minibilles.cli {
 
 import javax.ws.rs.core {
     context,
-    UriInfo
+    UriInfo,
+    HttpHeaders {
+        authorizationHeader = authorization
+    }
+}
+import ceylon.json {
+    JsonObject,
+    JsonArray,
+    parseJson = parse
 }
 shared abstract class MigrationEndpoint<Migration>()
         given Migration satisfies NamespaceMigration {
+    value bearerPrefix = "Bearer ";
+    value requestIdHeader = "X-Request-Id";
+    value identityIdHeader = "X-Identity-Id";
+    value namespaceHeader = "X-User-Namespace";
 
     shared formal String endpointName;
     value endpointDesc => "../``endpointName`` endpoint";
 
-    shared default Status post(String json) => doMigration<Migration> (endpointDesc, json);
+    shared default {<String->String>*} completeArguments(HttpHeaders headers) {
+        return {
+            if (exists requestId = headers.getHeaderString(requestIdHeader))
+            then "request-id"->requestId else null,
 
-    shared default Status get(context UriInfo info) => doMigration<Migration> (endpointDesc, [
-        for (param in info.getQueryParameters(true).entrySet())
-        "--``param.key``=``if (param.\ivalue.empty) then "" else param.\ivalue.get(0)``"
-    ]);
+            if (exists identityId = headers.getHeaderString(identityIdHeader))
+            then "identity-id"->identityId else null,
+
+            if (exists namespace = headers.getHeaderString(namespaceHeader))
+            then "os-namespace"->namespace else null,
+
+            if (exists auth = headers.getHeaderString(authorizationHeader),
+                auth.startsWith(bearerPrefix))
+            then "token" -> auth.spanFrom(bearerPrefix.size) else null,
+
+            if (exists auth = headers.getHeaderString(authorizationHeader),
+                auth.startsWith(bearerPrefix))
+            then "os-token" -> auth.spanFrom(bearerPrefix.size) else null
+        }.coalesced;
+    }
+
+    function overrideJson(HttpHeaders headers, JsonObject json) {
+        json.putAll(completeArguments(headers));
+        return json;
+    }
+
+    function parse(String json) =>
+        if (is JsonObject parsed = parseJson(json))
+        then parsed else JsonObject {};
+
+    shared default Status post(context HttpHeaders headers, String json)
+        => doMigration<Migration> (endpointDesc, overrideJson(headers,parse(json)));
+
+    shared default Status get(context HttpHeaders headers, context UriInfo info) => doMigration<Migration> (endpointDesc,
+        overrideJson(headers,JsonObject {
+            for (param in info.getQueryParameters(true).entrySet())
+            (param.key.string ->
+            (if(param.\ivalue.empty)
+            then true
+            else if(param.\ivalue.size() > 1)
+            then JsonArray({ for (v in param.\ivalue) v?.string })
+            else param.\ivalue.get(0)?.string))
+        }));
 
     shared default String help() => cliHelp<Migration>(endpointDesc);
 }

--- a/source/io/fabric8/tenant/che/migration/namespace/che5ToChe6/Endpoint.ceylon
+++ b/source/io/fabric8/tenant/che/migration/namespace/che5ToChe6/Endpoint.ceylon
@@ -8,11 +8,13 @@ import javax.ws.rs {
 import javax.ws.rs.core {
     MediaType,
     context,
-    UriInfo
+    UriInfo,
+    HttpHeaders
 }
 import io.fabric8.tenant.che.migration.namespace {
     MigrationEndpoint,
-    Status
+    Status,
+    environment
 }
 
 path(Name.name)
@@ -20,14 +22,22 @@ shared class Endpoint() extends MigrationEndpoint<Migration>() {
 
     endpointName => Name.name;
 
+    completeArguments(HttpHeaders headers) => super.completeArguments(headers).chain {
+        if (exists source = environment.multiTenantCheServer)
+        then "source" -> source else null,
+
+        if (exists destination = environment.cheDestinationServer)
+        then "destination" -> destination else null
+    }.coalesced;
+
     post
     produces {MediaType.applicationJson}
     consumes {MediaType.applicationJson}
-    shared actual Status post(String json) => super.post(json);
+    shared actual Status post(context HttpHeaders headers, String json) => super.post(headers, json);
 
     get
     produces {MediaType.applicationJson}
-    shared actual Status get(context UriInfo info) => super.get(info);
+    shared actual Status get(context HttpHeaders headers, context UriInfo info) => super.get(headers, info);
 
     get
     path("help")

--- a/source/io/fabric8/tenant/che/migration/namespace/che5ToChe6/Migration.ceylon
+++ b/source/io/fabric8/tenant/che/migration/namespace/che5ToChe6/Migration.ceylon
@@ -8,8 +8,7 @@ import ceylon.logging {
 }
 
 import fr.minibilles.cli {
-    option,
-    additionalDoc
+    option
 }
 
 import io.fabric8.kubernetes.api.model {
@@ -44,6 +43,8 @@ shared Migration withDefaultValues() => Migration(
     environment.identityId else "",
     environment.requestId else "",
     environment.jobRequestId else "",
+    environment.osNamespace else "",
+    environment.osToken else "",
     environment.debugLogs
 );
 
@@ -66,9 +67,11 @@ shared class Migration(
         String identityId = "",
         String requestId = "",
         String jobRequestId = "",
+        String namespace = environment.osNamespace else "",
+        String osToken = environment.osToken else "",
         Boolean debugLogs = false
 
-        ) extends NamespaceMigration(identityId, requestId, jobRequestId, debugLogs) {
+        ) extends NamespaceMigration(identityId, requestId, jobRequestId, namespace, osToken, debugLogs) {
 
     name = Name.name;
 

--- a/source/io/fabric8/tenant/che/migration/namespace/doMigration.ceylon
+++ b/source/io/fabric8/tenant/che/migration/namespace/doMigration.ceylon
@@ -10,14 +10,17 @@ import fr.minibilles.cli {
 import java.lang {
     System
 }
+import ceylon.json {
+    JsonObject
+}
 
-Status doMigration<Migration>(String programName, [String*]|String argumentsOrJson)
+Status doMigration<Migration>(String programName, [String*]|JsonObject argumentsOrJson)
     given Migration satisfies NamespaceMigration {
 
     System.setProperty("kubernetes.auth.tryKubeConfig", "true");
     try {
         value parsingResult = switch (argumentsOrJson)
-        case (is String) parseJson<Migration>(argumentsOrJson.string)
+        case (is JsonObject) parseJson<Migration>(argumentsOrJson.string)
         else parseArguments<Migration>(argumentsOrJson);
 
         switch (parsingResult)

--- a/source/io/fabric8/tenant/che/migration/namespace/environment.ceylon
+++ b/source/io/fabric8/tenant/che/migration/namespace/environment.ceylon
@@ -5,18 +5,20 @@ shared object environment {
             if (exists var=process.environmentVariableValue(name),
                 ! var.empty) then var else null;
 
-    shared variable String? migration = get("MIGRATION");
+    shared String? migration = get("MIGRATION");
     shared String? requestId = get("REQUEST_ID");
     shared String? identityId = get("IDENTITY_ID");
     shared String? jobRequestId = get("JOB_REQUEST_ID");
     shared String? osioToken = get("OSIO_TOKEN");
-    shared String? cheNamespace = get("CHE_NAMESPACE");
+    shared String? osNamespace = get("OS_NAMESPACE");
+    shared String? osMasterUrl = get("OS_MASTER_URL");
+    shared String? osToken = get("OS_TOKEN");
     shared Boolean debugLogs = if (exists debug = get("DEBUG"))
             then debug.lowercased.trimmed == "true" else false;
 
     shared String? multiTenantCheServer = get("CHE_MULTITENANT_SERVER");
     shared String? cleanupSingleTenant = get("CLEANUP_SINGLE_TENANT");
-    shared String? cheDestinationServer = get("CHE_DESTINATION_SERVER") else "";
+    shared String? cheDestinationServer = get("CHE_DESTINATION_SERVER");
 }
 
 

--- a/source/io/fabric8/tenant/che/migration/namespace/singleTenantToMultiTenant/Endpoint.ceylon
+++ b/source/io/fabric8/tenant/che/migration/namespace/singleTenantToMultiTenant/Endpoint.ceylon
@@ -8,7 +8,8 @@ import javax.ws.rs {
 import javax.ws.rs.core {
     MediaType,
     context,
-    UriInfo
+    UriInfo,
+    HttpHeaders
 }
 import io.fabric8.tenant.che.migration.namespace {
     MigrationEndpoint,
@@ -24,11 +25,11 @@ shared class Endpoint() extends MigrationEndpoint<Migration>() {
     post
     produces {MediaType.applicationJson}
     consumes {MediaType.applicationJson}
-    shared actual Status post(String json) => super.post(json);
+    shared actual Status post(context HttpHeaders headers, String json) => super.post(headers, json);
 
     get
     produces {MediaType.applicationJson}
-    shared actual Status get(context UriInfo info) => super.get(info);
+    shared actual Status get(context HttpHeaders headers, context UriInfo info) => super.get(headers, info);
 
     get
     path("help")

--- a/source/io/fabric8/tenant/che/migration/namespace/singleTenantToMultiTenant/Migration.ceylon
+++ b/source/io/fabric8/tenant/che/migration/namespace/singleTenantToMultiTenant/Migration.ceylon
@@ -4,8 +4,7 @@ import ceylon.logging {
 }
 
 import fr.minibilles.cli {
-    option,
-    additionalDoc
+    option
 }
 
 import io.fabric8.kubernetes.api.model {
@@ -41,6 +40,8 @@ shared Migration withDefaultValues() => Migration(
     environment.identityId else "",
     environment.requestId else "",
     environment.jobRequestId else "",
+    environment.osNamespace else "",
+    environment.osToken else "",
     environment.debugLogs
 );
 
@@ -67,9 +68,11 @@ shared class Migration(
         String identityId = "",
         String requestId = "",
         String jobRequestId = "",
+        String namespace = environment.osNamespace else "",
+        String osToken = environment.osToken else "",
         Boolean debugLogs = false
 
-        ) extends NamespaceMigration(identityId, requestId, jobRequestId, debugLogs) {
+        ) extends NamespaceMigration(identityId, requestId, jobRequestId, namespace, osToken, debugLogs) {
 
     name = Name.name;
 
@@ -89,7 +92,7 @@ shared class Migration(
 
         function serverCleaned(DeploymentConfigResource? deploymentConfig) => ! deploymentConfig?.get() exists;
 
-        try(oc = DefaultOpenShiftClient()) {
+        try(oc = DefaultOpenShiftClient(osConfig)) {
             value namespace = osioCheNamespace(oc);
 
             value lockResources = oc.configMaps().inNamespace(namespace).withName("migration-lock");
@@ -230,7 +233,7 @@ shared class Migration(
     }
 
     Boolean cleanSingleTenantCheServer() {
-        try(oc = DefaultOpenShiftClient()) {
+        try(oc = DefaultOpenShiftClient(osConfig)) {
             String namespace = osioCheNamespace(oc);
 
             log.info("Stopping the Che server in namespace `` namespace ``");


### PR DESCRIPTION
- Allow passing the OSIO token in the `Autorization` header
- Also get the `identity-id`, `request-id` from headers
- Support passing the user namespace, and customizing the cluster URL 